### PR TITLE
chore: bump drachtio-srf to ^5.0.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@jambonz/stats-collector": "^0.1.10",
         "bent": "^7.3.12",
         "debug": "^4.4.3",
-        "drachtio-srf": "^5.0.5",
+        "drachtio-srf": "^5.0.25",
         "express": "^4.21.2",
         "pino": "^10.1.0",
         "rtpengine-client": "^0.4.12",
@@ -1565,7 +1565,8 @@
     "node_modules/any-base": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1845,9 +1846,10 @@
       "dev": true
     },
     "node_modules/delegates": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
-      "integrity": "sha512-tPYr58xmVlUWcL8zPk6ZAxP6XqiYx5IIn395dkeER12JmMy8P6ipGKnUvgD++g8+uCaALfs/CRERixvKBu1pow=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
     },
     "node_modules/denque": {
       "version": "2.1.0",
@@ -1875,31 +1877,24 @@
       }
     },
     "node_modules/drachtio-srf": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/drachtio-srf/-/drachtio-srf-5.0.5.tgz",
-      "integrity": "sha512-dKdOf+zonTvk1eVu0IVc4a/Hdah2KspXngAeLQ3NZHdAkjQCJjYQZubVP6ho2QT1pzu8wA3U4M/atL1O99Ujzw==",
+      "version": "5.0.25",
+      "resolved": "https://registry.npmjs.org/drachtio-srf/-/drachtio-srf-5.0.25.tgz",
+      "integrity": "sha512-8AGJdRx4zKCrwQJbNL8e2OjdGsAZqdUgrnRnUftiv72AphrROj1pXr2Utt4rj7ccDp17VlbzE3qJXvQF8OoX6w==",
+      "license": "MIT",
       "dependencies": {
-        "debug": "^3.2.7",
-        "delegates": "^0.1.0",
-        "node-noop": "^0.0.1",
+        "debug": "^4.4.3",
+        "delegates": "^1.0.0",
+        "node-noop": "^1.0.0",
         "only": "^0.0.2",
         "sdp-transform": "^2.15.0",
-        "short-uuid": "^4.2.2",
+        "short-uuid": "^6.0.3",
         "sip-methods": "^0.3.0",
         "sip-status": "^0.1.0",
-        "utils-merge": "^1.0.0",
+        "utils-merge": "^1.0.1",
         "uuid-random": "^1.3.2"
       },
       "engines": {
         "node": ">= 18.x"
-      }
-    },
-    "node_modules/drachtio-srf/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -2804,9 +2799,10 @@
       }
     },
     "node_modules/node-noop": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/node-noop/-/node-noop-0.0.1.tgz",
-      "integrity": "sha512-kAUvIRxZyDYFTLqGj+7zqXduG89vtqGmNMt9qDMvYH3H8uNTCOTz5ZN1q2Yg8++fWbzv+ERtYVqaOH42Ag5OpA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-noop/-/node-noop-1.0.0.tgz",
+      "integrity": "sha512-1lpWqKwZ9yUosQfW1uy3jm6St4ZbmeDKKGmdzwzedbyBI4LgHtGyL1ofDdqiSomgaYaSERi+qWtj64huJQjl7g==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/object-inspect": {
       "version": "1.13.3",
@@ -3261,23 +3257,15 @@
       }
     },
     "node_modules/short-uuid": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-4.2.2.tgz",
-      "integrity": "sha512-IE7hDSGV2U/VZoCsjctKX6l5t5ak2jE0+aeGJi3KtvjIUNuZVmHVYUjNBhmo369FIWGDtaieRaO8A83Lvwfpqw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-6.0.3.tgz",
+      "integrity": "sha512-UMZ3rYOoid307EqWsPTnoBUSOB51Fi28vUMPigUsSCmbaSvslyf/SlXZWOn4btj8tokhBTBkPFKVKKlIolEG1w==",
+      "license": "MIT",
       "dependencies": {
-        "any-base": "^1.1.0",
-        "uuid": "^8.3.2"
+        "any-base": "^1.1.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/short-uuid/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@jambonz/stats-collector": "^0.1.10",
     "bent": "^7.3.12",
     "debug": "^4.4.3",
-    "drachtio-srf": "^5.0.5",
+    "drachtio-srf": "^5.0.25",
     "express": "^4.21.2",
     "pino": "^10.1.0",
     "rtpengine-client": "^0.4.12",


### PR DESCRIPTION
Updates drachtio-srf to the latest release (5.0.25), previously ^5.0.5.

Updated `package.json` and `package-lock.json` together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)